### PR TITLE
Set default timeout for all HTTP requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV LOG_LEVEL="DEBUG" \
     APP_BASE_URL="http://localhost:5000" \
     SMTP_HOST="localhost" \
     SMTP_PORT="25" \
-    SMTP_FROM_ADDR="sherpa@localhost"
+    SMTP_FROM_ADDR="sherpa@localhost" \
+    HTTP_DEFAULT_TIMEOUT="30"
 
 COPY ./app/ /app

--- a/app/auth_utils.py
+++ b/app/auth_utils.py
@@ -2,6 +2,7 @@ from flask import session
 import jwt
 import os
 import requests
+import utils
 from sherpa.utils.basics import Properties
 from sherpa.utils.basics import Logger
 import time
@@ -153,7 +154,7 @@ def refreshToken(logger: Logger, discovery_document: dict) -> bool:
                 'client_id': os.environ.get('OIDC_CLIENT_ID'),
                 'client_secret': os.environ.get('OIDC_CLIENT_SECRET'),
             },
-            timeout=10,
+            timeout=utils.DEFAULT_TIMEOUT,
         )
         if token_response.status_code >= 400:
             logger.debug("Token refresh rejected by IdP (HTTP {}).", token_response.status_code)

--- a/app/blueprints/change_email.py
+++ b/app/blueprints/change_email.py
@@ -21,13 +21,13 @@ def search_user(base_url: str, realm: str, access_token: str, target_user: str) 
     """Resolve target_user (username, UUID or email) to user id via IAM CRUD. Raises if not found."""
     headers = {"X-Realm": realm, "Authorization": f"Bearer {access_token}"}
     for param, value in [("username", target_user), ("identifier", target_user)]:
-        r = requests.get(f"{base_url}/v1/users/search", params={param: value}, headers=headers)
+        r = requests.get(f"{base_url}/v1/users/search", params={param: value}, headers=headers, timeout=utils.DEFAULT_TIMEOUT)
         r.raise_for_status()
         data = r.json()
         if isinstance(data, list) and len(data) > 0:
             user = data[0]
             return user["identifier"]
-    r = requests.get(f"{base_url}/v1/users", params={"emailAddress": target_user}, headers=headers)
+    r = requests.get(f"{base_url}/v1/users", params={"emailAddress": target_user}, headers=headers, timeout=utils.DEFAULT_TIMEOUT)
     r.raise_for_status()
     data = r.json()
     if isinstance(data, list) and len(data) > 0:
@@ -40,7 +40,7 @@ def change_email(base_url: str, realm: str, access_token: str, user_id: str, new
     """Call IAM CRUD PATCH /v1/users/{id}/change-email. Raises on non-204."""
     url = f"{base_url}/v1/users/{user_id}/change-email"
     headers = {"X-Realm": realm, "Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}
-    r = requests.patch(url, json={"emailAddress": new_email}, headers=headers)
+    r = requests.patch(url, json={"emailAddress": new_email}, headers=headers, timeout=utils.DEFAULT_TIMEOUT)
     if r.status_code != 204:
         try:
             err = r.json()

--- a/app/blueprints/user_sessions.py
+++ b/app/blueprints/user_sessions.py
@@ -63,12 +63,12 @@ def user_sessions_detail(environment: str, realm: str, userIdentifier: str):
     headers = {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json", "X-Realm": realm}
     params = {"userId": userIdentifier}
 
-    user_search_response = requests.get(f"{base_url}/v1/users/search", headers=headers, params={"username": userIdentifier})
+    user_search_response = requests.get(f"{base_url}/v1/users/search", headers=headers, params={"username": userIdentifier}, timeout=utils.DEFAULT_TIMEOUT)
     user = user_search_response.json()[0]
     username = user["username"]
     user_id = user["identifier"]
 
-    iamcrud_response = requests.get(f"{base_url}/v1/sessions", headers=headers, params=params)
+    iamcrud_response = requests.get(f"{base_url}/v1/sessions", headers=headers, params=params, timeout=utils.DEFAULT_TIMEOUT)
 
     payload = iamcrud_response.json()
     sessions = payload if isinstance(payload, list) else []
@@ -115,7 +115,7 @@ def kill_session(environment: str, realm: str, userIdentifier: str):
     base_url = (current_app.json_config.get("environments", {}).get(environment, {}).get("iamcrud_api_base_url"))
     access_token = auth_utils.getCurrentAccessToken(logger=current_app.logger, discovery_document=current_app.discovery_document)
     headers = {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json", "X-Realm": realm}
-    iamcrud_response = requests.delete(f"{base_url}/v1/sessions/{session_id}", headers=headers)
+    iamcrud_response = requests.delete(f"{base_url}/v1/sessions/{session_id}", headers=headers, timeout=utils.DEFAULT_TIMEOUT)
 
     if iamcrud_response.ok:
         flash(current_app.messages['usersesssions.kill_session_success'], 'success')
@@ -143,7 +143,7 @@ def kill_all_sessions(environment: str, realm: str, userIdentifier: str):
     access_token = auth_utils.getCurrentAccessToken(logger=current_app.logger, discovery_document=current_app.discovery_document)
     headers = {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json", "X-Realm": realm}
     params = {"userId": userIdentifier}
-    iamcrud_response = requests.delete(f"{base_url}/v1/sessions", headers=headers, params=params)
+    iamcrud_response = requests.delete(f"{base_url}/v1/sessions", headers=headers, params=params, timeout=utils.DEFAULT_TIMEOUT)
 
     if iamcrud_response.ok:
         flash(current_app.messages['usersesssions.kill_all_sessions_success'], 'success')

--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,7 @@ app.unrestricted_environments = os.environ.get('UNRESTRICTED_ENVIRONMENTS', 'loc
 
 issuer = os.environ.get('IDP_BASE_URL') + '/realms/' + os.environ.get('OIDC_REALM')
 discovery_endpoint = issuer + '/.well-known/openid-configuration'
-response = requests.get(discovery_endpoint)
+response = requests.get(discovery_endpoint, timeout=utils.DEFAULT_TIMEOUT)
 response.raise_for_status()
 app.discovery_document = response.json()
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -14,6 +14,9 @@ from sherpa.keycloak.keycloak_lib import SherpaKeycloakAdmin
 import smtplib
 
 
+DEFAULT_TIMEOUT = float(os.environ.get("HTTP_DEFAULT_TIMEOUT", "30"))
+
+
 def load_messages():
     """
     Load messages from default.messages, optionally overridden by custom.messages


### PR DESCRIPTION
Introduces a configurable default timeout for all external HTTP requests. This prevents indefinite hangs and improves application resilience by ensuring calls to external services do not block indefinitely.