### PR TITLE
Fix reporting of clients with no recorded activity

### DIFF
--- a/app/checkclients_report.py
+++ b/app/checkclients_report.py
@@ -455,7 +455,14 @@ def checkClientInactivity(logger: Logger, normalizedClient: dict, environment: s
     logger.trace(f"checkClientInactivity({normalizedClient['client_id']})")
     last_login_time = normalizedClient["last_login_time"]
     if not last_login_time:
-        return []
+        return [
+            getWarn(
+                logger=logger,
+                normalizedClient=normalizedClient,
+                issueLevel="WARN",
+                issueDescription="No activity has been recorded for this client"
+            )
+        ]
     threshold_months = config["environments"][environment].get("inactivity_months", 3)
     last_login_date = datetime.strptime(last_login_time, "%Y-%m-%d").date()
     months = (date.today().year - last_login_date.year) * 12 + date.today().month - last_login_date.month


### PR DESCRIPTION
The `checkClientInactivity` function previously returned an empty list when a client had no `last_login_time`, effectively ignoring them. This change now generates a warning for such clients, ensuring that missing activity data is properly flagged.