### PR TITLE
Streamline client metadata retrieval with explicit fallbacks

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -395,17 +395,12 @@ def getNormalizedClient(logger: Logger, properties: Properties, environment: str
         client_attributes = client.get("attributes") or {}
         client_description = client.get("description", "")
 
-        if client_attributes.get("custom_type") or client_attributes.get("owner.email"):
-            # Nuevo formato: la metadata viene en client attributes.
-            response["tag"] = getClientTag(logger=logger, description=client_description, client_id=client["clientId"], client_type=response["type"], custom_type=client_attributes.get("custom_type", ""))
-            response["owner_email"] = client_attributes.get("owner.email", "")
-            response["description"] = client_description
-        else:
-            # Formato anterior: la metadata se parsea desde la description.
-            # TODO: Deprecar el parseo de la description cuando se termine de definir la nomenclatura y se carguen los atributos en los clients.
-            response["tag"] = getClientTag(logger=logger, description=client_description, client_id=client["clientId"], client_type=response["type"])
-            response["owner_email"] = splitDescription(logger=logger, description=client_description, position=1, defaultValue="")
-            response["description"] = splitDescription(logger=logger, description=client_description, position=2, defaultValue=client_description)
+        # TODO: Deprecar el parseo de la description cuando se termine de definir la nomenclatura y se carguen los atributos en los clients.
+        custom_type_attr = client_attributes.get("custom_type", "")
+        owner_email_attr = client_attributes.get("owner.email", "")
+        response["tag"] = getClientTag(logger=logger, description=client_description, client_id=client["clientId"], client_type=response["type"], custom_type=custom_type_attr)
+        response["owner_email"] = owner_email_attr if owner_email_attr else splitDescription(logger=logger, description=client_description, position=1, defaultValue="")
+        response["description"] = splitDescription(logger=logger, description=client_description, position=2, defaultValue=client_description)
 
         if response["type"] == "realm":
             response["enabled"] = True


### PR DESCRIPTION
Refines the `getNormalizedClient` function by removing the conditional block that previously dictated an "all-or-nothing" approach for using structured `client.attributes` versus parsing values from the `description` field.

The updated logic now explicitly prioritizes attributes where available:
- `custom_type` from attributes is consistently used when generating the client tag.
- `owner_email` from attributes is prioritized, with a clear fallback to parsing the client description if the attribute is not found.
- The `description` field itself is now consistently parsed from the `client_description`.

This change improves the flexibility and robustness of the metadata extraction process during the ongoing migration to structured attributes.

Relates to CLR-912